### PR TITLE
calculate earnings when game is closed

### DIFF
--- a/LocalStorage.js
+++ b/LocalStorage.js
@@ -2,6 +2,8 @@ class LocalStorage {
 
   // Set Storage
     setStore (businesses) {
+      let day = new Date();
+      localStorage.setItem('time', JSON.stringify(day.getTime()));
       businesses.forEach( bus => {
         localStorage.setItem(bus, JSON.stringify(eval(bus)));
       });
@@ -12,6 +14,7 @@ class LocalStorage {
   // Get Storage
     getStore (businesses) {
       totalCash = JSON.parse(localStorage.getItem('totalCash'));
+
 
       businesses.forEach( bus => {
         let data = JSON.parse(localStorage.getItem(bus));
@@ -27,4 +30,23 @@ class LocalStorage {
       });
     }
 
+  // Create earnings when game is re-opened 
+    createEarnings(businesses) {
+      let timeNow = new Date();
+      let timeThen = JSON.parse(localStorage.getItem("time"));
+      let diff = timeNow.getTime() - timeThen;
+      if (diff > (12*60*60*1000)) {
+        diff = 12*60*60*1000;
+      }
+      let earnings = 0;
+      businesses.forEach( bus => {
+        earnings += (Math.floor(diff/eval(bus).totalTime)) * eval(bus).earningsPer;
+      });
+      if (earnings > 0) {
+        totalCash += earnings;
+        ui.updateCash();
+        console.log(earnings);
+        alert(`You earned ${earnings} while you were away!`);
+      }
+    }
 }

--- a/app.js
+++ b/app.js
@@ -1,4 +1,6 @@
- //initialize classes
+
+
+//initialize classes
  const store = new LocalStorage();
  const ui = new UI();
  //cost, time, earnings
@@ -16,7 +18,6 @@ window.addEventListener("load", () => {
   
   let test = JSON.parse(localStorage.getItem('lemonade')); 
   if (window.localStorage.length === 0 || test.costs.length === 0){ // if no local storage, calc Costs
-    console.log("1");
     lemonade.calcCosts();
     candy.calcCosts();
     coffee.calcCosts();  
@@ -28,7 +29,6 @@ window.addEventListener("load", () => {
     dragon.calcCosts();
     ui.updateCost(activeMultiplier,businesses);
   } else { // otherwise get info from storage
-    console.log("2");
       // get local storage, parseJSON, set game variables with response.
       store.getStore(businesses);
       businesses.forEach( (bus,index) => {
@@ -40,6 +40,7 @@ window.addEventListener("load", () => {
         ui.setTimestamp(businesses);
         update(timestamp);
       }); 
+      store.createEarnings(businesses);
   }
   
    
@@ -136,10 +137,8 @@ if (window.innerWidth > 992 ){
 window.addEventListener("resize", () => {
   let level = [1,10,25,100].indexOf(eval(activeMultiplier)) + 1;
     // if (window.innerWidth > 992 ) {
-      console.log(buyMultipliersNav[level].innerText);
       simulateClick(buyMultipliersNav[level]);
     // } else {
-      console.log(buyMultipliersNavMobile[level].innerText);
       simulateClick(buyMultipliersNavMobile[level]);
     // }
 });


### PR DESCRIPTION
This adds functionality that uses time stamps to calculate and to totalCash the money that was earned while the game was closed. If the time difference is greater than 12 hours, the earnings are limited to 12 hours.  If there are no earnings, nothing more happens.  Otherwise, the earnings are added to totalCash and an alert pops up showing how much was earned.